### PR TITLE
Change the type of `parse::parse`

### DIFF
--- a/src/ast_level3/type_check/simplify.rs
+++ b/src/ast_level3/type_check/simplify.rs
@@ -762,9 +762,7 @@ mod tests {
             -> Num | String forall t1, t2, t3, t4 --
             = ()
             "#,
-        )
-        .unwrap()
-        .1;
+        );
         let ast: ast_level1::Ast = ast.into();
         let ast: ast_level2::Ast = ast.into();
         let req_t = ast

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,28 +50,21 @@ pub fn run(source: &str, output_js: bool, loglevel: LevelFilter) {
             }
         }
     }
-    let (remaining, ast) = parse(source).unwrap();
-    if remaining.is_empty() {
-        let ast: ast_level1::Ast = ast.into();
-        let ast: ast_level2::Ast = ast.into();
-        let ast: ast_level3::Ast = ast.into();
-        let ast: ast_level4::Ast = ast.into();
-        let js = codegen(ast);
-        if output_js {
-            println!("{}", js);
-        } else {
-            Command::new("node")
-                .arg("--eval")
-                .arg(js)
-                .spawn()
-                .unwrap()
-                .wait()
-                .unwrap();
-        }
+    let ast = parse(source);
+    let ast: ast_level1::Ast = ast.into();
+    let ast: ast_level2::Ast = ast.into();
+    let ast: ast_level3::Ast = ast.into();
+    let ast: ast_level4::Ast = ast.into();
+    let js = codegen(ast);
+    if output_js {
+        println!("{}", js);
     } else {
-        eprintln!(
-            "unexpected input:\n{}\nast:\n{:?}",
-            remaining, ast
-        );
+        Command::new("node")
+            .arg("--eval")
+            .arg(js)
+            .spawn()
+            .unwrap()
+            .wait()
+            .unwrap();
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -23,7 +23,16 @@ fn separator1(input: &str) -> IResult<&str, Vec<char>> {
     many1(one_of("\r\n\t "))(input)
 }
 
-pub fn parse(source: &str) -> IResult<&str, Ast> {
+pub fn parse(source: &str) -> Ast {
+    let (remaining, ast) = ast(source).unwrap();
+    if remaining.is_empty() {
+        ast
+    } else {
+        panic!("unexpected input:\n{}\nast:\n{:?}", remaining, ast);
+    }
+}
+
+fn ast(source: &str) -> IResult<&str, Ast> {
     let (input, decls) = many1(dec)(source)?;
     Ok((input, Ast { decls }))
 }


### PR DESCRIPTION
Change `parse(source: &str) -> IResult<&str, Ast>` to `parse(source: &str) -> Ast`